### PR TITLE
Relations app

### DIFF
--- a/react/scss/_common.scss
+++ b/react/scss/_common.scss
@@ -1,1 +1,3 @@
 @import '~normalize.css';
+@import '~bootstrap/dist/css/bootstrap.css';
+

--- a/react/scss/composers-app.scss
+++ b/react/scss/composers-app.scss
@@ -1,4 +1,4 @@
-@import '~bootstrap/dist/css/bootstrap.css';
+@import 'common';
 
 .pagination__header, .pagination__search, .pagination__suggestions, .pagination__content, .pagination__footer {
   margin: 20px 0 20px 0;

--- a/react/scss/relations-app.scss
+++ b/react/scss/relations-app.scss
@@ -1,0 +1,44 @@
+@import 'common';
+
+.application__relations {
+  margin-top: 30px;
+}
+
+.application__search__field {
+  margin: 20px 0 20px 0;
+}
+
+.entity__title {
+  margin-bottom: 0;
+}
+
+.entity, .relation {
+  text-align: center;
+  font-size: 14px;
+}
+
+.entity-list__suggestions, .relation-list__suggestions {
+  text-align: center;
+}
+
+.entity-list__suggestions__title, .relation-list__suggestions__title {
+  border-bottom: 1px solid #999999;
+  padding-bottom: 10px;
+}
+.entity-list__suggestions__suggestion-list__item, .relation-list__suggestions__suggestion-list__item {
+  cursor: pointer;
+  margin-bottom: 10px;
+  font-size: 14px;
+}
+
+.entity-suggestion__title, .relation-suggestion__title {
+  margin-bottom: 0;
+}
+
+.entity-list__entity-list__item, .relation-list__entity-list__item {
+  margin-bottom: 10px;
+}
+
+.badge {
+  font-size: 9px;
+}

--- a/react/src/components/relations-app/Application.jsx
+++ b/react/src/components/relations-app/Application.jsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { Container, Row, Col } from 'reactstrap';
+
+import Entity from './Entity';
+import EntityList from './EntityList';
+import Relation from './Relation';
+import RelationList from './RelationList';
+import SearchField from './SearchField';
+import loadSuggestions from './remote/loadSuggestions';
+import loadRelations from './remote/loadRelations';
+import loadEntities from './remote/loadEntities';
+import '../../../scss/relations-app.scss';
+
+class Application extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      entity: {
+        title: 'Mozart',
+        type: 'composer',
+      },
+      relationSuggestion: null,
+      entitySuggestion: null,
+      query: '',
+      entities: [],
+      relations: [],
+      entitiesSuggestions: [],
+      relationsSuggestions: [],
+      showSuggestions: false,
+      loadingSuggestions: false,
+      loadingEntities: false,
+      loadingRelations: false,
+    };
+  }
+
+  onSearchChange(query) {
+    this.setState({
+      query,
+      showSuggestions: true,
+      loadingSuggestions: true,
+      loadingEntities: false,
+      loadingRelations: false,
+      relationSuggestion: null,
+      entitySuggestion: null,
+      entities: [],
+      relations: [],
+    });
+
+    loadSuggestions(query).then(suggestions => {
+      this.setState({
+        ...suggestions,
+        loadingSuggestions: false,
+      });
+    });
+  }
+
+  onEntitySuggestionClick(entitySuggestion) {
+    this.setState({
+      showSuggestions: false,
+      loadingRelations: true,
+      entitySuggestion,
+    });
+
+    loadRelations(entitySuggestion).then(result => {
+      this.setState({
+        ...result,
+        loadingRelations: false,
+      });
+    });
+  }
+
+  onRelationSuggestionClick(relationSuggestion) {
+    this.setState({
+      showSuggestions: false,
+      loadingEntities: true,
+      relationSuggestion,
+    });
+
+    loadEntities(relationSuggestion).then(result => {
+      this.setState({
+        ...result,
+        loadingEntities: false,
+      });
+    });
+  }
+
+  render() {
+    const {
+      query,
+      entity,
+      entities,
+      relations,
+      entitiesSuggestions,
+      relationsSuggestions,
+      showSuggestions,
+      loadingSuggestions,
+      loadingEntities,
+      loadingRelations,
+      relationSuggestion,
+      entitySuggestion,
+    } = this.state;
+
+    return (
+      <Container className="application">
+        <Row>
+          <Col>
+            <SearchField
+              query={query}
+              className="application__search__field"
+              handleSearchChange={(_query) => this.onSearchChange(_query)}
+              handleSearchClick={() => 3}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col sm={!!query ? '4' : '12'} xs="12">
+            <Entity
+              entity={entity}
+            />
+          </Col>
+          {!!query && (
+            <Col sm="4" xs="6">
+              {!!relationSuggestion && (
+                <Relation
+                  relation={relationSuggestion}
+                />
+              )}
+              {!relationSuggestion && (
+                <RelationList
+                  relations={relations}
+                  relationsSuggestions={relationsSuggestions}
+                  showSuggestions={showSuggestions}
+                  loadingSuggestions={loadingSuggestions}
+                  loadingRelations={loadingRelations}
+                  onRelationSuggestionClick={(_relationSuggestion) => this.onRelationSuggestionClick(_relationSuggestion)}
+                />
+              )}
+            </Col>
+          )}
+          {!!query && (
+            <Col sm="4" xs="6">
+              {!!entitySuggestion && (
+                <Entity
+                  entity={entitySuggestion}
+                />
+              )}
+              {!entitySuggestion && (
+                <EntityList
+                  entities={entities}
+                  entitiesSuggestions={entitiesSuggestions}
+                  showSuggestions={showSuggestions}
+                  loadingSuggestions={loadingSuggestions}
+                  loadingEntities={loadingEntities}
+                  onEntitySuggestionClick={(_entitySuggestion) => this.onEntitySuggestionClick(_entitySuggestion)}
+                />
+              )}
+            </Col>
+          )}
+        </Row>
+      </Container>
+    );
+  }
+}
+
+export default Application;

--- a/react/src/components/relations-app/Entity.jsx
+++ b/react/src/components/relations-app/Entity.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Badge } from 'reactstrap';
+
+
+class Entity extends React.Component {
+  render() {
+    const { entity, className } = this.props;
+
+    return (
+      <div className={`entity ${className}`}>
+        <p className="entity__title"> {entity.title} </p>
+        <Badge className="badge"> {entity.type} </Badge>
+      </div>
+    );
+  }
+}
+
+Entity.propTypes = {
+  entity: React.PropTypes.shape({
+    title: React.PropTypes.string.isRequired,
+    type: React.PropTypes.string.isRequired,
+  }).isRequired,
+  className: React.PropTypes.string,
+};
+
+export default Entity;

--- a/react/src/components/relations-app/EntityList.jsx
+++ b/react/src/components/relations-app/EntityList.jsx
@@ -1,0 +1,107 @@
+import _ from 'lodash';
+import React from 'react';
+import { Progress, Pagination, PaginationLink, PaginationItem } from 'reactstrap';
+
+import Entity from './Entity';
+import EntitySuggestion from './EntitySuggestion';
+
+
+const LIMIT = 5;
+const MAX_PAGES = 5;
+
+class EntityList extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      page: 1,
+    };
+  }
+
+  render() {
+    const {
+      entities,
+      showSuggestions,
+      entitiesSuggestions,
+      loadingSuggestions,
+      onEntitySuggestionClick,
+      loadingEntities,
+    } = this.props;
+
+    const { page } = this.state;
+
+    const numberPages = Math.min(MAX_PAGES, Math.ceil(entities.length / LIMIT));
+    const displayEntitiesSuggestions = entitiesSuggestions.slice(0, LIMIT);
+    const displayEntities = entities.slice((page - 1) * LIMIT, page * LIMIT);
+
+    return (
+      <div>
+        {!!showSuggestions && (
+          <div className="entity-list__suggestions">
+            <h6 className="entity-list__suggestions__title"> Suggestions... </h6>
+            {!loadingSuggestions && (
+              <div className="entity-list__suggestions__suggestion-list">
+                {_.map(displayEntitiesSuggestions, entitySuggestion =>
+                  <EntitySuggestion
+                    key={`${entitySuggestion.title}.${entitySuggestion.type}`}
+                    className="entity-list__suggestions__suggestion-list__item"
+                    entitySuggestion={entitySuggestion}
+                    onEntitySuggestionClick={onEntitySuggestionClick}
+                  />
+                )}
+              </div>
+            )}
+            {!!loadingSuggestions && (
+              <Progress value={75} />
+            )}
+          </div>
+        )}
+
+        {!showSuggestions && (
+          <div>
+            {!loadingEntities && (
+              <div className="entity-list__entity-list">
+                {_.map(displayEntities, entity =>
+                  <Entity
+                    key={`${entity.title}.${entity.type}`}
+                    className="entity-list__entity-list__item"
+                    entity={entity}
+                  />
+                )}
+                <Pagination style={{ display: 'flex', justifyContent: 'center' }}>
+                  {new Array(numberPages).fill(undefined).map((____, index) =>
+                    <PaginationItem key={index}>
+                      <PaginationLink href="#" onClick={() => this.setState({ page: index + 1 })}>
+                        {index + 1}
+                      </PaginationLink>
+                    </PaginationItem>
+                  )}
+                </Pagination>
+              </div>
+            )}
+            {!!loadingEntities && (
+              <Progress value={55}> Loading ... </Progress>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+EntityList.propTypes = {
+  entities: React.PropTypes.arrayOf(React.PropTypes.shape({
+    title: React.PropTypes.string,
+    type: React.PropTypes.string,
+  })).isRequired,
+  entitiesSuggestions: React.PropTypes.arrayOf(React.PropTypes.shape({
+    title: React.PropTypes.string,
+    type: React.PropTypes.string,
+  })).isRequired,
+  onEntitySuggestionClick: React.PropTypes.func.isRequired,
+  showSuggestions: React.PropTypes.bool.isRequired,
+  loadingSuggestions: React.PropTypes.bool.isRequired,
+  loadingEntities: React.PropTypes.bool.isRequired,
+};
+
+export default EntityList;

--- a/react/src/components/relations-app/EntitySuggestion.jsx
+++ b/react/src/components/relations-app/EntitySuggestion.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Badge } from 'reactstrap';
+
+
+class EntitySuggestion extends React.Component {
+  render() {
+    const {
+      className,
+      entitySuggestion,
+      onEntitySuggestionClick,
+    } = this.props;
+
+    return (
+      <div className={`entity-suggestion ${className}`} onClick={() => onEntitySuggestionClick(entitySuggestion)}>
+        <p className="entity-suggestion__title"> {entitySuggestion.title} </p>
+        <Badge className="badge"> {entitySuggestion.type} </Badge>
+      </div>
+    );
+  }
+}
+
+EntitySuggestion.propTypes = {
+  entitySuggestion: React.PropTypes.shape({
+    title: React.PropTypes.string,
+  }).isRequired,
+  onEntitySuggestionClick: React.PropTypes.func.isRequired,
+  className: React.PropTypes.string,
+};
+
+export default EntitySuggestion;

--- a/react/src/components/relations-app/Relation.jsx
+++ b/react/src/components/relations-app/Relation.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+
+class Relation extends React.Component {
+  render() {
+    const { relation } = this.props;
+
+    return (
+      <div className="relation">
+        <p className="relation__title">
+          {relation.title}
+        </p>
+      </div>
+    );
+  }
+}
+
+Relation.propTypes = {
+  relation: React.PropTypes.shape({
+    title: React.PropTypes.string,
+  }).isRequired,
+};
+
+export default Relation;

--- a/react/src/components/relations-app/RelationList.jsx
+++ b/react/src/components/relations-app/RelationList.jsx
@@ -1,0 +1,105 @@
+import _ from 'lodash';
+import React from 'react';
+import { Progress, Pagination, PaginationLink, PaginationItem } from 'reactstrap';
+
+import Relation from './Relation';
+import RelationSuggestion from './RelationSuggestion';
+
+
+const LIMIT = 5;
+const MAX_PAGES = 5;
+
+class RelationList extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      page: 1,
+    };
+  }
+
+  render() {
+    const {
+      relations,
+      showSuggestions,
+      relationsSuggestions,
+      loadingSuggestions,
+      onRelationSuggestionClick,
+      loadingRelations,
+    } = this.props;
+
+    const { page } = this.state;
+
+    const numberPages = Math.min(MAX_PAGES, Math.ceil(relations.length / LIMIT));
+    const displayRelations = relations.slice((page - 1) * LIMIT, page * LIMIT);
+    const displayRelationsSuggestions = relationsSuggestions.slice(0, LIMIT);
+
+    return (
+      <div>
+        {!!showSuggestions && (
+          <div className="relation-list__suggestions">
+            <h6 className="relation-list__suggestions__title"> Suggestions... </h6>
+            {!loadingSuggestions && (
+              <div className="relation-list__suggestions__suggestion-list">
+                {_.map(displayRelationsSuggestions, relationSuggestion =>
+                  <RelationSuggestion
+                    key={`${relationSuggestion.title}`}
+                    className="relation-list__suggestions__suggestion-list__item"
+                    relationSuggestion={relationSuggestion}
+                    onRelationSuggestionClick={onRelationSuggestionClick}
+                  />
+                )}
+              </div>
+            )}
+            {!!loadingSuggestions && (
+              <Progress value={60} />
+            )}
+          </div>
+        )}
+
+        {!showSuggestions && (
+          <div>
+            {!loadingRelations && (
+              <div className="relation-list__relation-list">
+                {_.map(displayRelations, relation =>
+                  <Relation
+                    key={`${relation.title}`}
+                    className="relation-list__relation-list__item"
+                    relation={relation}
+                  />
+                )}
+                <Pagination style={{ display: 'flex', justifyContent: 'center' }}>
+                  {new Array(numberPages).fill(undefined).map((____, index) =>
+                    <PaginationItem key={index}>
+                      <PaginationLink href="#" onClick={() => this.setState({ page: index + 1 })}>
+                        {index + 1}
+                      </PaginationLink>
+                    </PaginationItem>
+                  )}
+                </Pagination>
+              </div>
+            )}
+            {!!loadingRelations && (
+              <Progress value={55}> Loading ... </Progress>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+RelationList.propTypes = {
+  relations: React.PropTypes.arrayOf(React.PropTypes.shape({
+    title: React.PropTypes.string,
+  })).isRequired,
+  relationsSuggestions: React.PropTypes.arrayOf(React.PropTypes.shape({
+    title: React.PropTypes.string,
+  })).isRequired,
+  onRelationSuggestionClick: React.PropTypes.func.isRequired,
+  showSuggestions: React.PropTypes.bool.isRequired,
+  loadingSuggestions: React.PropTypes.bool.isRequired,
+  loadingRelations: React.PropTypes.bool.isRequired,
+};
+
+export default RelationList;

--- a/react/src/components/relations-app/RelationSuggestion.jsx
+++ b/react/src/components/relations-app/RelationSuggestion.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+
+class RelationSuggestion extends React.Component {
+  render() {
+    const {
+      className,
+      relationSuggestion,
+      onRelationSuggestionClick,
+    } = this.props;
+
+    return (
+      <div className={`relation-suggestion ${className}`} onClick={() => onRelationSuggestionClick(relationSuggestion)}>
+        <p className="relation-suggestion__title"> {relationSuggestion.title} </p>
+      </div>
+    );
+  }
+}
+
+RelationSuggestion.propTypes = {
+  relationSuggestion: React.PropTypes.shape({
+    title: React.PropTypes.string,
+  }).isRequired,
+  onRelationSuggestionClick: React.PropTypes.func.isRequired,
+  className: React.PropTypes.string,
+};
+
+export default RelationSuggestion;

--- a/react/src/components/relations-app/SearchField.jsx
+++ b/react/src/components/relations-app/SearchField.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { InputGroup, InputGroupAddon, Input } from 'reactstrap';
+
+
+const SearchField = props => (
+  <div className={`${props.className}`}>
+    <InputGroup>
+      <InputGroupAddon>Search</InputGroupAddon>
+      <Input
+        value={props.query}
+        placeholder="Composer, music piece, work or relation"
+        onChange={(e) => props.handleSearchChange(e.target.value)}
+      />
+    </InputGroup>
+  </div>
+);
+
+SearchField.propTypes = {
+  className: React.PropTypes.string,
+  query: React.PropTypes.string,
+  handleSearchChange: React.PropTypes.func.isRequired,
+  handleSearchClick: React.PropTypes.func.isRequired,
+};
+
+export default SearchField;

--- a/react/src/components/relations-app/remote/loadEntities.js
+++ b/react/src/components/relations-app/remote/loadEntities.js
@@ -1,0 +1,16 @@
+const entities = new Array(100).fill(undefined).map((_, index) => {
+  return {
+    title: `Composer${index}`,
+    type: new Array('Composer', 'Music Piece', 'Work')[Math.floor(Math.random() * 10) % 3],
+  };
+});
+
+export default function loadEntites(relationSuggestion) { // eslint-disable-line no-unused-vars
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve({
+        entities,
+      });
+    }, 750);
+  });
+}

--- a/react/src/components/relations-app/remote/loadRelations.js
+++ b/react/src/components/relations-app/remote/loadRelations.js
@@ -1,0 +1,15 @@
+const relations = new Array(100).fill(undefined).map((_, index) => {
+  return {
+    title: `Relation${index}`,
+  };
+});
+
+export default function loadRelations(entitySuggestion) { // eslint-disable-line no-unused-vars
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve({
+        relations,
+      });
+    }, 750);
+  });
+}

--- a/react/src/components/relations-app/remote/loadSuggestions.js
+++ b/react/src/components/relations-app/remote/loadSuggestions.js
@@ -1,0 +1,23 @@
+const entitiesSuggestions = [
+  { title: 'Compos', type: 'composer' },
+  { title: 'Composer', type: 'composer' },
+  { title: 'Composer1', type: 'composer' },
+];
+
+const relationsSuggestions = [
+  { title: 'Lik' },
+  { title: 'Likes' },
+  { title: 'Likes very m' },
+];
+
+
+export default function loadSuggestions(query = '') { // eslint-disable-line no-unused-vars
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve({
+        entitiesSuggestions,
+        relationsSuggestions,
+      });
+    }, 750);
+  });
+}

--- a/react/src/relations-app.js
+++ b/react/src/relations-app.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import injectTapEventPlugin from 'react-tap-event-plugin';
+
+import Application from './components/relations-app/Application';
+
+
+injectTapEventPlugin({
+  shouldRejectClick: 'ontouchstart' in window ? () => true : null,
+});
+
+function startApp() {
+  ReactDOM.render(<Application />, document.getElementById('react-app'));
+}
+
+startApp();

--- a/react/webpack.config.js
+++ b/react/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
     timelineApp: './src/timeline-app.js',
     personGraph: './src/person-graph.js',
     composersApp: './src/composers-app.js',
+    relationsApp: './src/relations-app.js',
   },
   output: {
     path: __dirname + '/../express/react',
@@ -33,6 +34,7 @@ module.exports = {
       { test: /\.scss$/, include: path.normalize(__dirname + '/scss/timeline-app.scss'), loader: 'style!css!autoprefixer!sass' },
       { test: /\.scss$/, include: path.normalize(__dirname + '/scss/person-graph.scss'), loader: 'style!css!autoprefixer!sass' },
       { test: /\.scss$/, include: path.normalize(__dirname + '/scss/composers-app.scss'), loader: 'style!css!autoprefixer!sass' },
+      { test: /\.scss$/, include: path.normalize(__dirname + '/scss/relations-app.scss'), loader: 'style!css!autoprefixer!sass' },
       { test: /\.css$/, include: /node_modules/, loader: 'style!css!autoprefixer' },
       { test: /\.json$/, loader: 'json' },
       { test: /\.png$/, loader: 'file' },
@@ -73,6 +75,12 @@ module.exports = {
       template: 'index.html',
       inject: 'body',
       chunks: ['composersApp'],
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'relations-app.html',
+      template: 'index.html',
+      inject: 'body',
+      chunks: ['relationsApp'],
     }),
   ],
   sassLoader: {


### PR DESCRIPTION
#42 
after @martomi is done with the API, we can integrate both. @martomi relevant for you is everything in folder `/remote`

We had requirements that the widgets takes very little space. Try it out on your PC cause the images dont speak too much. Works also if you click suggestion for composer, then it displays pagination with relations.



![1](https://cloud.githubusercontent.com/assets/20355307/24528865/cf75aa96-15a8-11e7-8953-6d88a00b43a4.png)
<img width="832" alt="screen shot 2017-03-31 at 00 30 48" src="https://cloud.githubusercontent.com/assets/20355307/24528967/52d653ea-15a9-11e7-91cb-a1118c2bdbd9.png">
![2](https://cloud.githubusercontent.com/assets/20355307/24528868/d14dacec-15a8-11e7-9a03-9b76c7237c97.png)
![3](https://cloud.githubusercontent.com/assets/20355307/24528871/d2ee489a-15a8-11e7-9f4b-72606d145945.png)
![4](https://cloud.githubusercontent.com/assets/20355307/24528876/d5cd4796-15a8-11e7-84b8-67948c92c48a.png)

